### PR TITLE
Format Cache change path to thumbnail

### DIFF
--- a/Media/FormatCache/PBFormatCache.php
+++ b/Media/FormatCache/PBFormatCache.php
@@ -62,7 +62,7 @@ final class PBFormatCache extends LocalFormatCache implements FormatCacheInterfa
     {
         $segmentPath = '/'.$this->getSegment($id);
         $fileName = $this->fileResolver->resolveFileName($fileName);
-        $filePath = $this->fileResolver->resolveFormatFilePath($segmentPath, $format, $fileName);
+        $filePath = $this->fileResolver->resolveFormatFilePath($id, $segmentPath, $format, $fileName);
 
         if (false === $this->filesystemProvider->exists($filePath)) {
             return null;
@@ -82,7 +82,7 @@ final class PBFormatCache extends LocalFormatCache implements FormatCacheInterfa
     {
         $segmentPath = '/'.$this->getSegment($id);
         $fileName = $this->fileResolver->resolveFileName($fileName);
-        $filePath = $this->fileResolver->resolveFormatFilePath($segmentPath, $format, $fileName);
+        $filePath = $this->fileResolver->resolveFormatFilePath($id, $segmentPath, $format, $fileName);
 
         try {
             $this->filesystemProvider->write($filePath, $content);
@@ -102,7 +102,7 @@ final class PBFormatCache extends LocalFormatCache implements FormatCacheInterfa
         $fileName = $this->fileResolver->resolveFileName($fileName);
 
         foreach ($this->formats as $format) {
-            $filePath = $this->fileResolver->resolveFormatFilePath($segmentPath, $format['key'], $fileName);
+            $filePath = $this->fileResolver->resolveFormatFilePath($id, $segmentPath, $format['key'], $fileName);
 
             try {
                 $this->filesystemProvider->delete($filePath);

--- a/Media/Resolver/FileResolver.php
+++ b/Media/Resolver/FileResolver.php
@@ -103,9 +103,9 @@ class FileResolver implements FileResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveFormatFilePath($folder, $format, $fileName)
+    public function resolveFormatFilePath($id, $folder, $format, $fileName)
     {
-        $path = $this->resolveFilePath($folder, $fileName);
+        $path = $this->resolveFilePath($folder, $id.'-'.$fileName);
 
         return '/'.ltrim($format, '/').'/'.ltrim($path, '/');
     }

--- a/Media/Resolver/FileResolverInterface.php
+++ b/Media/Resolver/FileResolverInterface.php
@@ -42,11 +42,12 @@ interface FileResolverInterface
     /**
      * Resolve format file path.
      *
+     * @param int $id
      * @param string $folder
      * @param string $format
      * @param string $fileName
      *
      * @return string
      */
-    public function resolveFormatFilePath($folder, $format, $fileName);
+    public function resolveFormatFilePath($id, $folder, $format, $fileName);
 }

--- a/Tests/Controller/MediaStreamControllerTest.php
+++ b/Tests/Controller/MediaStreamControllerTest.php
@@ -130,7 +130,7 @@ class MediaStreamControllerTest extends TestCase
         $this->assertFalse($actual->headers->has('X-Robots-Tag'));
         $this->assertSame($actual->headers->get('Content-Type'), $expectedMimeType);
         $this->assertSame($actual->headers->get('Content-Disposition'), 'attachment; filename="example.jpeg"');
-        $this->assertSame($actual->headers->get('Content-Length'), $fileSize);
+        $this->assertSame($actual->headers->get('Content-Length'), (string)$fileSize);
         $this->assertSame($actual->headers->get('Last-Modified'), $lastModified->format('D, d M Y H:i:s \G\M\T'));
     }
 
@@ -215,7 +215,7 @@ class MediaStreamControllerTest extends TestCase
         $this->assertSame($actual->headers->get('X-Robots-Tag'), 'noindex, follow');
         $this->assertSame($actual->headers->get('Content-Type'), $mimeType);
         $this->assertSame($actual->headers->get('Content-Disposition'), 'attachment; filename="example.jpeg"');
-        $this->assertSame($actual->headers->get('Content-Length'), $fileSize);
+        $this->assertSame($actual->headers->get('Content-Length'), (string)$fileSize);
         $this->assertSame($actual->headers->get('Last-Modified'), $lastModified->format('D, d M Y H:i:s \G\M\T'));
     }
 

--- a/Tests/Media/FormatCache/PBFormatCacheTest.php
+++ b/Tests/Media/FormatCache/PBFormatCacheTest.php
@@ -85,7 +85,7 @@ class PBFormatCacheTest extends TestCase
         // Mock FileResolverInterface::resolveFormatFilePath()
         $expectedFilePath = $format.'/'.ltrim($expectedSegmentPath, '/').'/'.$fileName;
         $this->frMock
-            ->resolveFormatFilePath($expectedSegmentPath, $format, $fileName)
+            ->resolveFormatFilePath($id, $expectedSegmentPath, $format, $fileName)
             ->shouldBeCalledTimes(1)
             ->willReturn($expectedFilePath);
         ;
@@ -130,7 +130,7 @@ class PBFormatCacheTest extends TestCase
 
         // Mock FileResolverInterface::resolveFormatFilePath()
         $this->frMock
-            ->resolveFormatFilePath($expectedSegmentPath, $format, $fileName)
+            ->resolveFormatFilePath($id, $expectedSegmentPath, $format, $fileName)
             ->shouldBeCalledTimes(1)
             ->willReturn($expectedFilePath);
         ;
@@ -164,7 +164,7 @@ class PBFormatCacheTest extends TestCase
         // End
 
         // Mock FileResolverInterface::resolveFilePath()
-        $this->frMock->resolveFormatFilePath('/05', $format, $fileName)->shouldBeCalledTimes(1)->willReturn($formatFilePath);
+        $this->frMock->resolveFormatFilePath($id, '/05', $format, $fileName)->shouldBeCalledTimes(1)->willReturn($formatFilePath);
         // End
 
         // Mock FilesystemProviderInterface::write()
@@ -194,7 +194,7 @@ class PBFormatCacheTest extends TestCase
         // End
 
         // Mock FileResolverInterface::resolveFilePath()
-        $this->frMock->resolveFormatFilePath('/05', $format, $fileName)->shouldBeCalledTimes(1)->willReturn($formatFilePath);
+        $this->frMock->resolveFormatFilePath($id, '/05', $format, $fileName)->shouldBeCalledTimes(1)->willReturn($formatFilePath);
         // End
 
         // Mock FilesystemProviderInterface::write()
@@ -223,7 +223,7 @@ class PBFormatCacheTest extends TestCase
             $filePath = '/'.$format['key'].'/01/'.$fileName;
 
             // Mock FileResolverInterface::resolveFilePath()
-            $this->frMock->resolveFormatFilePath('/01', $format['key'], $fileName)->shouldBeCalledTimes(1)->willReturn($filePath);
+            $this->frMock->resolveFormatFilePath($id, '/01', $format['key'], $fileName)->shouldBeCalledTimes(1)->willReturn($filePath);
             // End
 
             // Mock FilesystemProviderInterface::remove()
@@ -253,7 +253,7 @@ class PBFormatCacheTest extends TestCase
             $filePath = '/'.$format['key'].'/01/'.$fileName;
 
             // Mock FileResolverInterface::resolveFilePath()
-            $this->frMock->resolveFormatFilePath('/01', $format['key'], $fileName)->shouldBeCalledTimes(1)->willReturn($filePath);
+            $this->frMock->resolveFormatFilePath($id, '/01', $format['key'], $fileName)->shouldBeCalledTimes(1)->willReturn($filePath);
             // End
 
             // Mock FilesystemProviderInterface::remove()

--- a/Tests/Media/Resolver/FileResolverTest.php
+++ b/Tests/Media/Resolver/FileResolverTest.php
@@ -190,9 +190,9 @@ class FileResolverTest extends TestCase
     public function resolveFormatFilePathDataProvider()
     {
         return [
-            ['/format-1/foo/bar/file.jpeg', '/foo/bar', 'format-1', 'file.jpeg'],
-            ['/format-2/foo/bar/file.jpeg', '/foo/bar/', 'format-2', '/file.jpeg'],
-            ['/format-3/foo/bar/file.jpeg', 'foo/bar/', '/format-3', '/file.jpeg'],
+            ['/format-1/foo/bar/1-file.jpeg', 1, '/foo/bar', 'format-1', 'file.jpeg'],
+            ['/format-2/foo/bar/20-file.jpeg', 20, '/foo/bar/', 'format-2', 'file.jpeg'],
+            ['/format-3/foo/bar/30-file.jpeg', 30, 'foo/bar/', '/format-3', 'file.jpeg'],
         ];
     }
 
@@ -200,14 +200,15 @@ class FileResolverTest extends TestCase
      * @dataProvider resolveFormatFilePathDataProvider
      *
      * @param $expected
+     * @param $id
      * @param $folder
      * @param $format
      * @param $fileName
      */
-    public function testResolveFormatFilePath($expected, $folder, $format, $fileName)
+    public function testResolveFormatFilePath($expected, $id, $folder, $format, $fileName)
     {
         // When
-        $actual = $this->buildResolver()->resolveFormatFilePath($folder, $format, $fileName);
+        $actual = $this->buildResolver()->resolveFormatFilePath($id, $folder, $format, $fileName);
 
         // Then
         $this->assertSame($expected, $actual);


### PR DESCRIPTION
- Fix few test cases related to variable type
- Format cache: add media ID to function `resolveFormatFilePath`, so the local path to thumbnail will contain ID right before filename - the same path as thumbnails are requested using `{{ media.thumbnails['800x450'] }}` in twig, so thumbnails will be returned by web-server next time. Update tests.